### PR TITLE
backwards compatibility w/ api changes to uv_afer_work_cb sig

### DIFF
--- a/src/XpcConnection.cpp
+++ b/src/XpcConnection.cpp
@@ -64,7 +64,7 @@ void XpcConnection::handleEvent(xpc_object_t event) {
 
   req->data = data;
 
-  uv_queue_work(uv_default_loop(), req, XpcConnection::HandleEvent, XpcConnection::HandleEventAfter);
+  uv_queue_work(uv_default_loop(), req, XpcConnection::HandleEvent, (uv_after_work_cb)XpcConnection::HandleEventAfter);
 }
 
 v8::Handle<v8::Value> XpcConnection::New(const v8::Arguments& args) {


### PR DESCRIPTION
Hi Sandeep, I was having some issues installing xpc-connection on 0.11.x

```
../src/XpcConnection.cpp:67:3: error: no matching function for call to 'uv_queue_work'
  uv_queue_work(uv_default_loop(), req, XpcConnection::HandleEvent, XpcConnection::HandleEventAfter);
  ^~~~~~~~~~~~~
```

After looking through some of the changelogs it seems as though a few signatures have changed

> The uv_after_work_cb signature has changed to take a second integer argument indicating status.
> For backwards compatibility, explicitly cast the 4th argument to uv_queue_work
> https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10

I've updated XpcConnection.cpp to include the new cast and everything seems to be working. Thanks for the awesome module!
