### PR TITLE
add an XpcConnection.prototype.stop() method

### DIFF
--- a/src/XpcConnection.cpp
+++ b/src/XpcConnection.cpp
@@ -22,6 +22,7 @@ NAN_MODULE_INIT(XpcConnection::Init) {
 
   Nan::SetPrototypeMethod(tmpl, "setup", Setup);
   Nan::SetPrototypeMethod(tmpl, "sendMessage", SendMessage);
+  Nan::SetPrototypeMethod(tmpl, "stop", Stop);
 
   target->Set(Nan::New("XpcConnection").ToLocalChecked(), tmpl->GetFunction());
 }
@@ -54,6 +55,10 @@ void XpcConnection::setup() {
   });
 
   xpc_connection_resume(this->xpcConnnection);
+}
+
+void XpcConnection::stop() {
+  uv_close((uv_handle_t*)this->asyncHandle, (uv_close_cb)XpcConnection::AsyncCloseCallback);
 }
 
 void XpcConnection::sendMessage(xpc_object_t message) {
@@ -92,6 +97,17 @@ NAN_METHOD(XpcConnection::Setup) {
   XpcConnection* p = node::ObjectWrap::Unwrap<XpcConnection>(info.This());
 
   p->setup();
+
+  info.GetReturnValue().SetUndefined();
+}
+
+
+NAN_METHOD(XpcConnection::Stop) {
+  Nan::HandleScope scope;
+
+  XpcConnection* p = node::ObjectWrap::Unwrap<XpcConnection>(info.This());
+
+  p->stop();
 
   info.GetReturnValue().SetUndefined();
 }

--- a/src/XpcConnection.h
+++ b/src/XpcConnection.h
@@ -18,6 +18,7 @@ public:
   static NAN_METHOD(New);
   static NAN_METHOD(Setup);
   static NAN_METHOD(SendMessage);
+  static NAN_METHOD(Stop);
 
 private:
   XpcConnection(std::string serviceName);
@@ -38,6 +39,7 @@ private:
   void sendMessage(xpc_object_t message);
   void queueEvent(xpc_object_t event);
   void processEventQueue();
+  void stop();
 
 private:
   std::string serviceName;

--- a/test.js
+++ b/test.js
@@ -2,7 +2,6 @@ var XpcConnection = require('./index');
 
 var bluedService = new XpcConnection('com.apple.blued');
 
-
 bluedService.on('error', function(message) {
   console.log('error: ' + JSON.stringify(message, undefined, 2));
 });
@@ -15,13 +14,19 @@ bluedService.on('event', function(event) {
 bluedService.setup();
 
 bluedService.sendMessage({
-  kCBMsgId: 1, 
+  kCBMsgId: 1,
   kCBMsgArgs: {
     kCBMsgArgAlert: 1,
     kCBMsgArgName: 'node'
   }
 });
 
+
+setTimeout(function() {
+  bluedService.stop();
+  console.log('handle closed');
+}, 3000);
+
 setTimeout(function() {
   console.log('done');
-}, 5000);
+}, 4000);


### PR DESCRIPTION
for #16 and [@sandeepmistry/noble#299](https://github.com/sandeepmistry/noble/issues/299) and [this comment](https://github.com/sandeepmistry/noble/pull/577#pullrequestreview-32956983)
 on [@sandeepmistry/noble#577](https://github.com/sandeepmistry/noble/issues/577).

now admittedly i have no idea what i'm doing here, but it does appear to work. at first i tried canceling the connection with `xpc_connection_cancel(this->xpcConnection)` but it sure took that badly

so now it is closing and deleting the handle like it would in the destructor

i do not know if this is the right thing to do, but it seems to work (does not prevent the node process from ending)