### PR TITLE
use bindings for native lib require

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   'targets': [
     {
-      'target_name': 'binding',
+      'target_name': 'xpc-connection',
       'conditions': [
         ['OS=="mac"', {
           'sources': [

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var events = require('events');
 
-var binding = require('./build/Release/binding.node');
+var binding = require('bindings')('xpc-connection.node');
 var XpcConnection = binding.XpcConnection;
 
 inherits(XpcConnection, events.EventEmitter);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "darwin"
   ],
   "dependencies": {
+    "bindings": "~1.3.0",
     "nan": "^2.4.0"
   }
 }


### PR DESCRIPTION
This PR just use ```bindings``` to load the native lib. Also renames the native lib.
It's useful for people trying to use webpack.
Used by a lot of libs right now